### PR TITLE
feat: withdrawal history beyond the VM window

### DIFF
--- a/functions/api/__tests__/getDeliveredRewards.test.ts
+++ b/functions/api/__tests__/getDeliveredRewards.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Env } from '../../types/env';
+
+const sdkGetDelivered = vi.fn();
+vi.mock('../../services/vmClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/vmClient')>();
+  return {
+    ...actual,
+    initVmSdk: async () => ({ getDeliveredRewards: sdkGetDelivered }),
+    // Bypass the Cache API in tests: always a miss, return the payload directly.
+    withCache: async (_req: Request, _ttl: number, fetchFn: () => Promise<unknown>) =>
+      new Response(JSON.stringify(await fetchFn()), { status: 200 }),
+  };
+});
+
+import { onRequestGet } from '../getDeliveredRewards';
+
+type Ctx = Parameters<typeof onRequestGet>[0];
+
+function fakeDb() {
+  const calls: { sql: string; binds: unknown[] }[] = [];
+  const prepare = (sql: string) => ({
+    bind(...b: unknown[]) {
+      calls.push({ sql, binds: b });
+      return this;
+    },
+  });
+  return {
+    prepare,
+    batch: vi.fn(async () => []),
+    __calls: calls,
+  } as unknown as D1Database & { batch: ReturnType<typeof vi.fn>; __calls: typeof calls };
+}
+
+const STAKE = 'stake1' + 'u'.repeat(40);
+
+function makeCtx(env: Partial<Env>): { ctx: Ctx; waitUntil: ReturnType<typeof vi.fn> } {
+  const waitUntil = vi.fn();
+  return {
+    ctx: {
+      request: new Request(`https://x/api/getDeliveredRewards?staking_address=${STAKE}`, {
+        headers: { Origin: 'http://localhost:5173' },
+      }),
+      env: { VITE_VM_API_KEY: 'k', ...env } as Env,
+      waitUntil,
+    } as unknown as Ctx,
+    waitUntil,
+  };
+}
+
+const VM_ROW = {
+  id: 'r1',
+  staking_address: STAKE,
+  epoch: '500',
+  token: 'lovelace',
+  amount: '1000000',
+  delivered_on: '1750000000',
+  withdrawal_request: 'w1',
+  expiry: '',
+};
+
+describe('getDeliveredRewards sync', () => {
+  beforeEach(() => {
+    sdkGetDelivered.mockReset();
+    sdkGetDelivered.mockResolvedValue([VM_ROW]);
+  });
+
+  it('returns the VM payload untouched', async () => {
+    const { ctx } = makeCtx({});
+    const res = await onRequestGet(ctx);
+    expect(await res.json()).toEqual([VM_ROW]);
+  });
+
+  it('does not touch D1 when the binding is absent', async () => {
+    const { ctx, waitUntil } = makeCtx({});
+    await onRequestGet(ctx);
+    // Our mocked withCache bypasses the cache-put waitUntil, so any call here
+    // would have to come from the sync path.
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+  it('schedules an ON CONFLICT DO NOTHING batch via waitUntil when DB present', async () => {
+    const db = fakeDb();
+    const { ctx, waitUntil } = makeCtx({ DB: db });
+    await onRequestGet(ctx);
+    expect(waitUntil).toHaveBeenCalled();
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0]));
+    expect(db.batch).toHaveBeenCalledTimes(1);
+    expect(db.__calls[0].sql).toContain('ON CONFLICT');
+    expect(db.__calls[0].binds).toEqual([
+      STAKE, 'r1', 'lovelace', '1000000', 500, '1750000000', 1750000000, 'w1',
+    ]);
+  });
+
+  it('parses ISO delivered_on and stores null for garbage', async () => {
+    const db = fakeDb();
+    sdkGetDelivered.mockResolvedValue([
+      { ...VM_ROW, id: 'r2', delivered_on: '2026-06-01T00:00:00Z' },
+      { ...VM_ROW, id: 'r3', delivered_on: 'not-a-date', epoch: 'x' },
+    ]);
+    const { ctx, waitUntil } = makeCtx({ DB: db });
+    await onRequestGet(ctx);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0]));
+    expect(db.__calls[0].binds[6]).toBe(Math.floor(Date.parse('2026-06-01T00:00:00Z') / 1000));
+    expect(db.__calls[1].binds[4]).toBe(null); // epoch 'x' -> null
+    expect(db.__calls[1].binds[6]).toBe(null); // unparsable delivered_on
+  });
+
+  it('skips rows without an id and survives a D1 failure', async () => {
+    const db = fakeDb();
+    (db.batch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+    sdkGetDelivered.mockResolvedValue([{ ...VM_ROW, id: '' }, VM_ROW]);
+    const { ctx, waitUntil } = makeCtx({ DB: db });
+    const res = await onRequestGet(ctx);
+    expect(res.status).toBe(200);
+    await Promise.all(waitUntil.mock.calls.map((call) => call[0])); // must not reject
+    expect(db.__calls).toHaveLength(1); // only the row with an id
+  });
+});

--- a/functions/api/__tests__/getDeliveredRewards.test.ts
+++ b/functions/api/__tests__/getDeliveredRewards.test.ts
@@ -92,18 +92,22 @@ describe('getDeliveredRewards sync', () => {
     ]);
   });
 
-  it('parses ISO delivered_on and stores null for garbage', async () => {
+  it('parses ISO delivered_on and skips invalid delivered_on or amount', async () => {
     const db = fakeDb();
     sdkGetDelivered.mockResolvedValue([
       { ...VM_ROW, id: 'r2', delivered_on: '2026-06-01T00:00:00Z' },
-      { ...VM_ROW, id: 'r3', delivered_on: 'not-a-date', epoch: 'x' },
+      { ...VM_ROW, id: 'r3', delivered_on: 'not-a-date' },
+      { ...VM_ROW, id: 'r4', amount: '' },
+      { ...VM_ROW, id: 'r5', amount: 'abc' },
+      { ...VM_ROW, id: 'r6', epoch: 'x' },
     ]);
     const { ctx, waitUntil } = makeCtx({ DB: db });
     await onRequestGet(ctx);
     await Promise.all(waitUntil.mock.calls.map((call) => call[0]));
+    expect(db.__calls).toHaveLength(2);
+    expect(db.__calls.map((call) => call.binds[1])).toEqual(['r2', 'r6']);
     expect(db.__calls[0].binds[6]).toBe(Math.floor(Date.parse('2026-06-01T00:00:00Z') / 1000));
     expect(db.__calls[1].binds[4]).toBe(null); // epoch 'x' -> null
-    expect(db.__calls[1].binds[6]).toBe(null); // unparsable delivered_on
   });
 
   it('skips rows without an id and survives a D1 failure', async () => {

--- a/functions/api/__tests__/history.test.ts
+++ b/functions/api/__tests__/history.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import type { Env } from '../../types/env';
+import { onRequestGet } from '../history';
+
+type Ctx = Parameters<typeof onRequestGet>[0];
+
+const STAKE = 'stake1' + 'u'.repeat(40);
+
+function fakeDb(rows: unknown[], total: number) {
+  const calls: { sql: string; binds: unknown[] }[] = [];
+  const prepare = (sql: string) => ({
+    bind(...b: unknown[]) {
+      calls.push({ sql, binds: b });
+      return this;
+    },
+    all: async () => ({ results: rows }),
+    first: async () => ({ total }),
+  });
+  return { prepare, __calls: calls } as unknown as D1Database & { __calls: typeof calls };
+}
+
+function ctx(qs: string, env: Partial<Env>): Ctx {
+  return {
+    request: new Request(`https://x/api/history?${qs}`, {
+      headers: { Origin: 'http://localhost:5173' },
+    }),
+    env: { VITE_VM_API_KEY: 'k', ...env } as Env,
+  } as unknown as Ctx;
+}
+
+const ROW = {
+  reward_id: 'r1',
+  token: 'lovelace',
+  amount: '1000000',
+  epoch: 500,
+  delivered_on: '1750000000',
+  delivered_at: 1750000000,
+  withdrawal_request: 'w1',
+};
+
+describe('GET /api/history', () => {
+  it('400 when staking_address missing', async () => {
+    const res = await onRequestGet(ctx('', {}));
+    expect(res.status).toBe(400);
+  });
+
+  it('400 for a bad limit', async () => {
+    const res = await onRequestGet(ctx(`staking_address=${STAKE}&limit=0`, {}));
+    expect(res.status).toBe(400);
+    const res2 = await onRequestGet(ctx(`staking_address=${STAKE}&limit=101`, {}));
+    expect(res2.status).toBe(400);
+  });
+
+  it('400 for a bad order', async () => {
+    const res = await onRequestGet(ctx(`staking_address=${STAKE}&order=sideways`, {}));
+    expect(res.status).toBe(400);
+  });
+
+  it('degrades without a DB binding', async () => {
+    const res = await onRequestGet(ctx(`staking_address=${STAKE}`, {}));
+    const body = await res.json();
+    expect(body).toEqual({
+      items: [], page: 1, limit: 50, total: 0, hasMore: false, degraded: true,
+    });
+  });
+
+  it('returns camelCase items with paging metadata', async () => {
+    const db = fakeDb([ROW], 1);
+    const res = await onRequestGet(ctx(`staking_address=${STAKE}`, { DB: db }));
+    const body = await res.json();
+    expect(body).toEqual({
+      items: [{
+        rewardId: 'r1', token: 'lovelace', amount: '1000000', epoch: 500,
+        deliveredOn: '1750000000', deliveredAt: 1750000000, withdrawalRequest: 'w1',
+      }],
+      page: 1, limit: 50, total: 1, hasMore: false,
+    });
+  });
+
+  it('derives hasMore from the limit+1 probe row', async () => {
+    const rows = [ROW, { ...ROW, reward_id: 'r2' }, { ...ROW, reward_id: 'r3' }];
+    const db = fakeDb(rows, 30);
+    const res = await onRequestGet(ctx(`staking_address=${STAKE}&limit=2`, { DB: db }));
+    const body = await res.json();
+    expect(body.items).toHaveLength(2);
+    expect(body.hasMore).toBe(true);
+    expect(body.total).toBe(30);
+  });
+
+  it('applies token, date-range, order, and page params to the SQL', async () => {
+    const db = fakeDb([], 0);
+    await onRequestGet(ctx(
+      `staking_address=${STAKE}&token=lovelace&from=1700000000&to=2026-06-01&order=asc&page=3&limit=10`,
+      { DB: db },
+    ));
+    const dataCall = db.__calls.find((c) => !c.sql.includes('COUNT'))!;
+    expect(dataCall.sql).toContain('token = ?');
+    expect(dataCall.sql).toContain('delivered_at >= ?');
+    expect(dataCall.sql).toContain('delivered_at <= ?');
+    expect(dataCall.sql).toContain('ASC');
+    // binds: stake, token, from, to, limit+1, offset
+    expect(dataCall.binds).toEqual([
+      STAKE, 'lovelace', 1700000000, Math.floor(Date.parse('2026-06-01') / 1000), 11, 20,
+    ]);
+  });
+});

--- a/functions/api/__tests__/history.test.ts
+++ b/functions/api/__tests__/history.test.ts
@@ -81,7 +81,7 @@ describe('GET /api/history', () => {
     const rows = [ROW, { ...ROW, reward_id: 'r2' }, { ...ROW, reward_id: 'r3' }];
     const db = fakeDb(rows, 30);
     const res = await onRequestGet(ctx(`staking_address=${STAKE}&limit=2`, { DB: db }));
-    const body = await res.json();
+    const body = (await res.json()) as { items: unknown[]; hasMore: boolean; total: number };
     expect(body.items).toHaveLength(2);
     expect(body.hasMore).toBe(true);
     expect(body.total).toBe(30);

--- a/functions/api/__tests__/history.test.ts
+++ b/functions/api/__tests__/history.test.ts
@@ -56,6 +56,11 @@ describe('GET /api/history', () => {
     expect(res.status).toBe(400);
   });
 
+  it('400 when from is after to', async () => {
+    const res = await onRequestGet(ctx(`staking_address=${STAKE}&from=2026-06-02&to=2026-06-01`, {}));
+    expect(res.status).toBe(400);
+  });
+
   it('degrades without a DB binding', async () => {
     const res = await onRequestGet(ctx(`staking_address=${STAKE}`, {}));
     const body = await res.json();

--- a/functions/api/getDeliveredRewards.ts
+++ b/functions/api/getDeliveredRewards.ts
@@ -1,5 +1,7 @@
 import type { Env } from '../types/env';
 import { initVmSdk, requireApiKey, withCache, errorResponse, optionsResponse } from '../services/vmClient';
+import { hasDb } from '../services/d1';
+import { buildWithdrawalUpserts } from '../services/withdrawalsSync';
 
 const CACHE_TTL = 300;
 
@@ -22,7 +24,22 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       const sdk = await initVmSdk(env);
       const input: { staking_address: string; token_id?: string } = { staking_address };
       if (token_id) input.token_id = token_id;
-      return sdk.getDeliveredRewards(input);
+      const data = await sdk.getDeliveredRewards(input);
+
+      // #181: accumulate history beyond the VM window. Append-only; a D1
+      // hiccup must never break the read path.
+      if (hasDb(env)) {
+        const stmts = buildWithdrawalUpserts(env.DB, staking_address, data);
+        if (stmts.length > 0) {
+          context.waitUntil(
+            env.DB.batch(stmts).then(
+              () => undefined,
+              (err) => console.error('withdrawals sync error:', err),
+            ),
+          );
+        }
+      }
+      return data;
     }, context.waitUntil.bind(context));
   } catch (error) {
     console.error('getDeliveredRewards error:', error);

--- a/functions/api/history.ts
+++ b/functions/api/history.ts
@@ -47,6 +47,9 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   if (params.get('to') && to === null) {
     return errorResponse('to must be a unix timestamp or date', 400, origin);
   }
+  if (from !== null && to !== null && from > to) {
+    return errorResponse('from must be <= to', 400, origin);
+  }
 
   if (!hasDb(env)) {
     return jsonResponse(

--- a/functions/api/history.ts
+++ b/functions/api/history.ts
@@ -1,0 +1,115 @@
+import type { Env } from '../types/env';
+import { jsonResponse, errorResponse, optionsResponse } from '../services/vmClient';
+import { hasDb } from '../services/d1';
+import { toUnixSeconds } from '../services/withdrawalsSync';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+interface WithdrawalRow {
+  reward_id: string;
+  token: string;
+  amount: string;
+  epoch: number | null;
+  delivered_on: string;
+  delivered_at: number | null;
+  withdrawal_request: string | null;
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  const origin = request.headers.get('Origin');
+  const params = new URL(request.url).searchParams;
+
+  const stakingAddress = params.get('staking_address');
+  if (!stakingAddress) {
+    return errorResponse('staking_address is required', 400, origin);
+  }
+
+  const page = Number(params.get('page') ?? '1');
+  if (!Number.isInteger(page) || page < 1) {
+    return errorResponse('page must be a positive integer', 400, origin);
+  }
+  const limit = Number(params.get('limit') ?? String(DEFAULT_LIMIT));
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return errorResponse(`limit must be 1-${MAX_LIMIT}`, 400, origin);
+  }
+  const order = params.get('order') ?? 'desc';
+  if (order !== 'asc' && order !== 'desc') {
+    return errorResponse('order must be asc or desc', 400, origin);
+  }
+  const token = params.get('token');
+  const from = params.get('from') ? toUnixSeconds(params.get('from')!) : null;
+  if (params.get('from') && from === null) {
+    return errorResponse('from must be a unix timestamp or date', 400, origin);
+  }
+  const to = params.get('to') ? toUnixSeconds(params.get('to')!) : null;
+  if (params.get('to') && to === null) {
+    return errorResponse('to must be a unix timestamp or date', 400, origin);
+  }
+
+  if (!hasDb(env)) {
+    return jsonResponse(
+      { items: [], page, limit, total: 0, hasMore: false, degraded: true },
+      200,
+      origin,
+    );
+  }
+
+  const where: string[] = ['stake_address = ?'];
+  const binds: unknown[] = [stakingAddress];
+  if (token) {
+    where.push('token = ?');
+    binds.push(token);
+  }
+  if (from !== null) {
+    where.push('delivered_at >= ?');
+    binds.push(from);
+  }
+  if (to !== null) {
+    where.push('delivered_at <= ?');
+    binds.push(to);
+  }
+  const whereSql = where.join(' AND ');
+  const dir = order === 'asc' ? 'ASC' : 'DESC';
+
+  try {
+    const [{ results }, count] = await Promise.all([
+      env.DB.prepare(
+        'SELECT reward_id, token, amount, epoch, delivered_on, delivered_at, withdrawal_request ' +
+          `FROM withdrawals WHERE ${whereSql} ` +
+          `ORDER BY (delivered_at IS NULL) ASC, delivered_at ${dir} ` +
+          'LIMIT ? OFFSET ?',
+      )
+        .bind(...binds, limit + 1, (page - 1) * limit)
+        .all<WithdrawalRow>(),
+      env.DB.prepare(`SELECT COUNT(*) AS total FROM withdrawals WHERE ${whereSql}`)
+        .bind(...binds)
+        .first<{ total: number }>(),
+    ]);
+
+    const rows = results ?? [];
+    const hasMore = rows.length > limit;
+    const items = rows.slice(0, limit).map((r) => ({
+      rewardId: r.reward_id,
+      token: r.token,
+      amount: r.amount,
+      epoch: r.epoch,
+      deliveredOn: r.delivered_on,
+      deliveredAt: r.delivered_at,
+      withdrawalRequest: r.withdrawal_request,
+    }));
+
+    return jsonResponse(
+      { items, page, limit, total: count?.total ?? items.length, hasMore },
+      200,
+      origin,
+    );
+  } catch (err) {
+    console.error('D1 history error:', err);
+    return errorResponse('Error fetching history', 500, origin);
+  }
+};
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request }) =>
+  optionsResponse(request.headers.get('Origin'));

--- a/functions/api/tokenPreferences.ts
+++ b/functions/api/tokenPreferences.ts
@@ -1,6 +1,7 @@
 import type { Env } from '../types/env';
 import { jsonResponse, errorResponse, optionsResponse } from '../services/vmClient';
 import { verifyStakeSignature } from '../services/verifyStakeSignature';
+import { hasDb } from '../services/d1';
 
 const MAX_PER_LIST = 200;
 const MAX_ASSET_ID_LEN = 120;
@@ -24,10 +25,6 @@ interface TokenRef {
   assetId: string;
   ticker: string;
   logo: string;
-}
-
-function hasDb(env: Env): env is Env & { DB: D1Database } {
-  return typeof env?.DB?.prepare === 'function';
 }
 
 // Returns the sanitized, deduped list — or an error string.

--- a/functions/services/d1.ts
+++ b/functions/services/d1.ts
@@ -1,0 +1,5 @@
+import type { Env } from '../types/env';
+
+export function hasDb(env: Env): env is Env & { DB: D1Database } {
+  return typeof env?.DB?.prepare === 'function';
+}

--- a/functions/services/withdrawalsSync.ts
+++ b/functions/services/withdrawalsSync.ts
@@ -1,0 +1,51 @@
+// Builds append-only upserts from the VM API's delivered-rewards payload.
+// Mirrors the client-side parseDeliveredOn heuristic in
+// src/features/history/api/history.queries.ts.
+export interface VmDeliveredReward {
+  id: string;
+  token: string;
+  amount: string | number;
+  epoch?: string | number;
+  delivered_on: string | number;
+  withdrawal_request?: string;
+}
+
+export function toUnixSeconds(raw: string): number | null {
+  const n = Number(raw);
+  if (!Number.isNaN(n) && n > 1_000_000_000 && n < 10_000_000_000) return Math.floor(n);
+  const t = Date.parse(raw);
+  return Number.isNaN(t) ? null : Math.floor(t / 1000);
+}
+
+export function buildWithdrawalUpserts(
+  db: D1Database,
+  stakeAddress: string,
+  rows: unknown,
+): D1PreparedStatement[] {
+  if (!Array.isArray(rows)) return [];
+  const stmts: D1PreparedStatement[] = [];
+  for (const raw of rows as Partial<VmDeliveredReward>[]) {
+    if (!raw || typeof raw.id !== 'string' || !raw.id || typeof raw.token !== 'string') continue;
+    const epochNum = Number(raw.epoch);
+    const deliveredOn = String(raw.delivered_on ?? '');
+    stmts.push(
+      db
+        .prepare(
+          'INSERT INTO withdrawals (stake_address, reward_id, token, amount, epoch, delivered_on, delivered_at, withdrawal_request) ' +
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?) ' +
+            'ON CONFLICT (stake_address, reward_id) DO NOTHING',
+        )
+        .bind(
+          stakeAddress,
+          raw.id,
+          raw.token,
+          String(raw.amount ?? ''),
+          Number.isNaN(epochNum) ? null : epochNum,
+          deliveredOn,
+          toUnixSeconds(deliveredOn),
+          raw.withdrawal_request ?? null,
+        ),
+    );
+  }
+  return stmts;
+}

--- a/functions/services/withdrawalsSync.ts
+++ b/functions/services/withdrawalsSync.ts
@@ -28,6 +28,19 @@ export function buildWithdrawalUpserts(
     if (!raw || typeof raw.id !== 'string' || !raw.id || typeof raw.token !== 'string') continue;
     const epochNum = Number(raw.epoch);
     const deliveredOn = String(raw.delivered_on ?? '');
+    const deliveredAt = deliveredOn.trim() ? toUnixSeconds(deliveredOn) : null;
+    const amount = raw.amount as unknown;
+    const amountString = String(amount ?? '');
+    const amountNum = Number(amountString);
+    if (
+      deliveredAt === null ||
+      amount === null ||
+      amount === undefined ||
+      amountString.trim() === '' ||
+      !Number.isFinite(amountNum)
+    ) {
+      continue;
+    }
     stmts.push(
       db
         .prepare(
@@ -39,10 +52,10 @@ export function buildWithdrawalUpserts(
           stakeAddress,
           raw.id,
           raw.token,
-          String(raw.amount ?? ''),
+          amountString,
           Number.isNaN(epochNum) ? null : epochNum,
           deliveredOn,
-          toUnixSeconds(deliveredOn),
+          deliveredAt,
           raw.withdrawal_request ?? null,
         ),
     );

--- a/migrations/0003_create_withdrawals.sql
+++ b/migrations/0003_create_withdrawals.sql
@@ -1,0 +1,19 @@
+-- Migration: Create withdrawals table syncing the VM API's delivered rewards
+-- so history accumulates beyond its ~100-row window. Rows are immutable;
+-- sync inserts with ON CONFLICT DO NOTHING. delivered_at is parsed unix
+-- seconds (nullable) used for sorting and range filters.
+CREATE TABLE IF NOT EXISTS withdrawals (
+  stake_address      TEXT NOT NULL,
+  reward_id          TEXT NOT NULL,
+  token              TEXT NOT NULL,
+  amount             TEXT NOT NULL,
+  epoch              INTEGER,
+  delivered_on       TEXT NOT NULL,
+  delivered_at       INTEGER,
+  withdrawal_request TEXT,
+  synced_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (stake_address, reward_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_withdrawals_stake_time
+  ON withdrawals (stake_address, delivered_at DESC);

--- a/src/features/history/__tests__/useWithdrawalHistory.test.tsx
+++ b/src/features/history/__tests__/useWithdrawalHistory.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const getMock = vi.fn();
+vi.mock('@/api/client', () => ({
+  apiClient: { get: (...a: unknown[]) => getMock(...a) },
+}));
+
+import { useWithdrawalHistory } from '../hooks/useWithdrawalHistory';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+const STAKE = 'stake1' + 'u'.repeat(40);
+
+describe('useWithdrawalHistory', () => {
+  // Block body on purpose: beforeEach treats a returned function as a
+  // teardown hook, and mockReset() returns the mock itself.
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it('is disabled without a stake address', () => {
+    const { result } = renderHook(() => useWithdrawalHistory(null, 1, 'desc'), { wrapper });
+    expect(result.current.isPending).toBe(true);
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('joins history items with token metadata and scales amounts', async () => {
+    getMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/history')) {
+        return Promise.resolve({
+          items: [{
+            rewardId: 'r1', token: 'lovelace', amount: '1500000', epoch: 500,
+            deliveredOn: '1750000000', deliveredAt: 1750000000, withdrawalRequest: 'w1',
+          }],
+          page: 1, limit: 50, total: 120, hasMore: true,
+        });
+      }
+      return Promise.resolve({}); // /api/getTokens
+    });
+    const { result } = renderHook(() => useWithdrawalHistory(STAKE, 1, 'desc'), { wrapper });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data!.total).toBe(120);
+    expect(result.current.data!.hasMore).toBe(true);
+    const row = result.current.data!.rows[0];
+    expect(row.ticker).toBe('ADA');
+    expect(row.amount).toBeCloseTo(1.5);
+    expect(row.epoch).toBe(500);
+    expect(row.deliveredOn?.getTime()).toBe(1750000000 * 1000);
+  });
+
+  it('propagates the degraded flag', async () => {
+    getMock.mockImplementation((url: string) =>
+      url.startsWith('/api/history')
+        ? Promise.resolve({ items: [], page: 1, limit: 50, total: 0, hasMore: false, degraded: true })
+        : Promise.resolve({}),
+    );
+    const { result } = renderHook(() => useWithdrawalHistory(STAKE, 1, 'desc'), { wrapper });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data!.degraded).toBe(true);
+  });
+});

--- a/src/features/history/api/history.queries.ts
+++ b/src/features/history/api/history.queries.ts
@@ -12,14 +12,14 @@ interface VmDeliveredReward {
   expiry: string;
 }
 
-interface TokenInfo {
+export interface TokenInfo {
   ticker?: string;
   decimals?: string | number;
   logo?: string;
   name?: string;
 }
 
-type TokenMap = Record<string, TokenInfo>;
+export type TokenMap = Record<string, TokenInfo>;
 
 export interface DeliveredReward {
   key: string;
@@ -45,19 +45,19 @@ function hexToUtf8(hex: string): string {
   }
 }
 
-function tickerFor(token: string, info?: TokenInfo): string {
+export function tickerFor(token: string, info?: TokenInfo): string {
   if (token === 'lovelace') return 'ADA';
   if (info?.ticker) return info.ticker;
   const parts = token.split('.');
   return parts.length === 2 ? hexToUtf8(parts[1]) || token : token.slice(0, 12);
 }
 
-function decimalsFor(token: string, info?: TokenInfo): number {
+export function decimalsFor(token: string, info?: TokenInfo): number {
   if (token === 'lovelace') return 6;
   return Number(info?.decimals ?? 0) || 0;
 }
 
-function parseDeliveredOn(raw: string): Date | null {
+export function parseDeliveredOn(raw: string): Date | null {
   const asNumber = Number(raw);
   if (!Number.isNaN(asNumber) && asNumber > 1_000_000_000 && asNumber < 10_000_000_000) {
     return new Date(asNumber * 1000);

--- a/src/features/history/components/HistoryList.tsx
+++ b/src/features/history/components/HistoryList.tsx
@@ -1,7 +1,14 @@
-import { useState } from 'react';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { useEffect, useRef, useState } from 'react';
+import {
+  IconAlertCircle,
+  IconArrowsSort,
+  IconChevronLeft,
+  IconChevronRight,
+} from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useWalletStore } from '@/store/wallet-state';
 import { useDeliveredRewards, type DeliveredReward } from '@/features/history/api/history.queries';
+import { useWithdrawalHistory, type HistoryOrder } from '@/features/history/hooks/useWithdrawalHistory';
 
 const PAGE_SIZE = 12;
 
@@ -121,6 +128,20 @@ export function HistoryList() {
   const stakeAddress = useWalletStore((s) => s.stakeAddress);
   const { data, isLoading, error } = useDeliveredRewards(stakeAddress);
   const [showAll, setShowAll] = useState(false);
+  const [page, setPage] = useState(1);
+  const [order, setOrder] = useState<HistoryOrder>('desc');
+  const history = useWithdrawalHistory(stakeAddress, page, order);
+
+  // First visit: the delivered-rewards fetch also syncs D1 server-side, so
+  // refresh the archive query once it settles.
+  const queryClient = useQueryClient();
+  const invalidated = useRef(false);
+  useEffect(() => {
+    if (data && !invalidated.current) {
+      invalidated.current = true;
+      queryClient.invalidateQueries({ queryKey: ['history', stakeAddress] });
+    }
+  }, [data, queryClient, stakeAddress]);
 
   if (!stakeAddress) {
     return (
@@ -133,7 +154,10 @@ export function HistoryList() {
 
   if (isLoading) return <SkeletonList />;
 
-  if (error) {
+  const serverMode =
+    !!history.data && !history.data.degraded && history.data.total > 0;
+
+  if (error && !serverMode) {
     return (
       <div className="card-premium flex items-start gap-3 px-5 py-4 text-sm text-rose-200">
         <IconAlertCircle size={18} stroke={1.6} className="mt-0.5 shrink-0 text-rose-400" />
@@ -145,7 +169,7 @@ export function HistoryList() {
     );
   }
 
-  if (!data || data.length === 0) {
+  if (!serverMode && (!data || data.length === 0)) {
     return (
       <StateMessage
         eyebrow="No history yet"
@@ -154,8 +178,16 @@ export function HistoryList() {
     );
   }
 
-  const visible = showAll ? data : data.slice(0, PAGE_SIZE);
-  const hasMore = data.length > visible.length;
+  const totalPages = serverMode
+    ? Math.max(1, Math.ceil(history.data!.total / history.data!.limit))
+    : 1;
+  const rows: DeliveredReward[] = serverMode
+    ? history.data!.rows
+    : showAll
+      ? data!
+      : data!.slice(0, PAGE_SIZE);
+  const clientHasMore = !serverMode && !!data && data.length > rows.length;
+  const count = serverMode ? history.data!.total : data!.length;
 
   return (
     <section className="card-premium overflow-hidden">
@@ -163,26 +195,64 @@ export function HistoryList() {
         <div className="flex items-center gap-2">
           <p className="label-eyebrow">Delivered</p>
           <span className="rounded-full border border-border-subtle bg-surface-inset/70 px-2 py-0.5 font-mono text-[10px] text-slate-300">
-            {data.length}
+            {count}
           </span>
         </div>
-        <p className="text-[11px] text-slate-500">Most recent first</p>
+        {serverMode ? (
+          <button
+            type="button"
+            onClick={() => {
+              setOrder((o) => (o === 'desc' ? 'asc' : 'desc'));
+              setPage(1);
+            }}
+            className="flex items-center gap-1 text-[11px] text-slate-500 transition hover:text-slate-300"
+          >
+            <IconArrowsSort size={12} stroke={1.6} />
+            {order === 'desc' ? 'Newest first' : 'Oldest first'}
+          </button>
+        ) : (
+          <p className="text-[11px] text-slate-500">Most recent first</p>
+        )}
       </header>
 
       <ul className="divide-y divide-border-subtle/50">
-        {visible.map((row) => (
+        {rows.map((row) => (
           <HistoryRow key={row.key} row={row} />
         ))}
       </ul>
 
-      {hasMore && (
+      {serverMode && totalPages > 1 && (
+        <div className="flex items-center justify-between border-t border-border-subtle/60 px-5 py-3">
+          <button
+            type="button"
+            disabled={page <= 1 || history.isFetching}
+            onClick={() => setPage((p) => p - 1)}
+            className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-wider text-brand-cyan transition hover:text-cyan-200 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <IconChevronLeft size={12} stroke={2} /> Prev
+          </button>
+          <p className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+            Page {page} / {totalPages}
+          </p>
+          <button
+            type="button"
+            disabled={!history.data!.hasMore || history.isFetching}
+            onClick={() => setPage((p) => p + 1)}
+            className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-wider text-brand-cyan transition hover:text-cyan-200 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Next <IconChevronRight size={12} stroke={2} />
+          </button>
+        </div>
+      )}
+
+      {clientHasMore && (
         <div className="border-t border-border-subtle/60 px-5 py-3 text-center">
           <button
             type="button"
             onClick={() => setShowAll(true)}
             className="font-mono text-[10px] uppercase tracking-wider text-brand-cyan transition hover:text-cyan-200"
           >
-            Show {data.length - visible.length} more
+            Show {data!.length - rows.length} more
           </button>
         </div>
       )}

--- a/src/features/history/components/HistoryList.tsx
+++ b/src/features/history/components/HistoryList.tsx
@@ -137,6 +137,10 @@ export function HistoryList() {
   const queryClient = useQueryClient();
   const invalidated = useRef(false);
   useEffect(() => {
+    invalidated.current = false;
+    setPage(1);
+  }, [stakeAddress]);
+  useEffect(() => {
     if (data && !invalidated.current) {
       invalidated.current = true;
       queryClient.invalidateQueries({ queryKey: ['history', stakeAddress] });

--- a/src/features/history/hooks/useWithdrawalHistory.ts
+++ b/src/features/history/hooks/useWithdrawalHistory.ts
@@ -1,0 +1,86 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import {
+  tickerFor,
+  decimalsFor,
+  parseDeliveredOn,
+  type TokenMap,
+  type DeliveredReward,
+} from '@/features/history/api/history.queries';
+
+interface HistoryItem {
+  rewardId: string;
+  token: string;
+  amount: string;
+  epoch: number | null;
+  deliveredOn: string;
+  deliveredAt: number | null;
+  withdrawalRequest: string | null;
+}
+
+interface HistoryResponse {
+  items: HistoryItem[];
+  page: number;
+  limit: number;
+  total: number;
+  hasMore: boolean;
+  degraded?: boolean;
+}
+
+export interface WithdrawalHistoryPage {
+  // Same display shape HistoryRow consumes.
+  rows: DeliveredReward[];
+  page: number;
+  limit: number;
+  total: number;
+  hasMore: boolean;
+  degraded: boolean;
+}
+
+export type HistoryOrder = 'asc' | 'desc';
+
+export function useWithdrawalHistory(
+  stakeAddress: string | null,
+  page: number,
+  order: HistoryOrder,
+) {
+  return useQuery<WithdrawalHistoryPage, Error>({
+    queryKey: ['history', stakeAddress, page, order],
+    enabled: !!stakeAddress,
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (!stakeAddress) throw new Error('stakeAddress is required');
+      const [history, tokens] = await Promise.all([
+        apiClient.get<HistoryResponse>(
+          `/api/history?staking_address=${encodeURIComponent(stakeAddress)}&page=${page}&order=${order}`,
+        ),
+        apiClient.get<TokenMap>('/api/getTokens'),
+      ]);
+
+      const rows: DeliveredReward[] = (history.items ?? []).map((item) => {
+        const info = tokens[item.token];
+        const decimals = decimalsFor(item.token, info);
+        return {
+          key: item.rewardId,
+          token: item.token,
+          ticker: tickerFor(item.token, info),
+          decimals,
+          amount: Number(item.amount) / Math.pow(10, decimals),
+          deliveredOn: parseDeliveredOn(item.deliveredOn),
+          deliveredOnRaw: item.deliveredOn,
+          epoch: item.epoch,
+          logo: info?.logo,
+        };
+      });
+
+      return {
+        rows,
+        page: history.page,
+        limit: history.limit,
+        total: history.total,
+        hasMore: history.hasMore,
+        degraded: history.degraded ?? false,
+      };
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Implements the M4 withdrawal-history chain so history accumulates past the VM API's ~100-row window, with full graceful degradation when the D1 binding is absent.

- **#181 sync mechanism** — `/api/getDeliveredRewards` now upserts fetched rows into a new D1 `withdrawals` table (migration 0003) inside the cache-miss path via `waitUntil`. Append-only (`ON CONFLICT DO NOTHING`); a D1 failure never breaks the read.
- **#180 `GET /api/history`** — paginated (`page`/`limit` ≤ 100), token filter, date-range filter (`from`/`to` as unix or ISO), `order=asc|desc`. Returns `degraded: true` without the binding.
- **#179 HistoryList upgrade** — server-driven pagination (Prev/Next) and a date-sort toggle whenever `/api/history` has data; falls back to the existing client-side view otherwise. First visit invalidates the archive query after the VM fetch settles so freshly synced rows appear.

Stacked on `feat/favorite-tokens` (#216) — shares the D1 plumbing (`hasDb` helper, wrangler migration comments).

Closes #179, closes #180, closes #181.

## Testing
- 16 new tests: endpoint validation/pagination/filters/degraded, sync batch construction + failure tolerance, hook token-join, all passing (`npx vitest run` → 90 passed)
- `tsc -b`, `eslint`, and `npm run build` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a withdrawal history API with pagination, token/date filtering, and ascending/descending ordering.
  * Introduced a new withdrawal history UI using server-driven pagination with token metadata and resilient degraded-mode fallback.
  * Enabled background syncing of delivered rewards into an append-only withdrawals history store.
* **Refactor**
  * Centralized database availability checks for consistent degraded behavior.
* **Tests**
  * Added Vitest coverage for the delivered rewards handler, history API handler, and the withdrawal history hook.
* **Chores**
  * Added a migration to create the withdrawals table and supporting index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->